### PR TITLE
fix(ios): showSplash depending on a current thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 
 
-# **📖 react-native-splash-view**  
+# **📖 react-native-splash-view**
 A lightweight and customizable splash screen module for React Native.
 
 [![npm version](https://img.shields.io/npm/v/react-native-splash-view)](https://www.npmjs.com/package/react-native-splash-view)
-[![License](https://img.shields.io/github/license/jagnesh/react-native-splash-view)](https://github.com/jagnesh/react-native-splash-view?tab=MIT-1-ov-file#readme) 
+[![License](https://img.shields.io/github/license/jagnesh/react-native-splash-view)](https://github.com/jagnesh/react-native-splash-view?tab=MIT-1-ov-file#readme)
 
 ---
 
-## **✨ Features**  
-✅ Show and hide splash screen programmatically  
-✅ Lightweight and fast  
-✅ Supports both iOS and Android  
+## **✨ Features**
+✅ Show and hide splash screen programmatically
+✅ Lightweight and fast
+✅ Supports both iOS and Android
 
 
 ---
@@ -22,36 +22,36 @@ A lightweight and customizable splash screen module for React Native.
 ---
 
 
-## **📦 Installation**  
+## **📦 Installation**
 
-### **Using npm**  
+### **Using npm**
 ```sh
 npm install react-native-splash-view
 ```
 
-### **Using yarn**  
+### **Using yarn**
 ```sh
 yarn add react-native-splash-view
 ```
 
 ---
 
-## **🛠️ Setup Instructions**  
+## **🛠️ Setup Instructions**
 
-### **📱 iOS Setup**  
-1️⃣ Install CocoaPods dependencies:  
+### **📱 iOS Setup**
+1️⃣ Install CocoaPods dependencies:
 ```sh
 cd ios && pod install --repo-update && cd ..
 ```
-2️⃣ Ensure `SplashView` is correctly linked.  
+2️⃣ Ensure `SplashView` is correctly linked.
 
-3️⃣ **Create a Storyboard for Splash Screen**:  
-- Open **Xcode** and go to the **LaunchScreen.storyboard** file.  
-- Ensure the **Storyboard Name** is set as `LaunchScreen`.  
-- This will be used as the splash screen when the app starts.  
+3️⃣ **Create a Storyboard for Splash Screen**:
+- Open **Xcode** and go to the **LaunchScreen.storyboard** file.
+- Ensure the **Storyboard Name** is set as `LaunchScreen`.
+- This will be used as the splash screen when the app starts.
 
-4️⃣ **Modify `AppDelegate`** to show the splash screen programmatically:  
-### If you are using swift update AppDelegate.swift 
+4️⃣ **Modify `AppDelegate`** to show the splash screen programmatically:
+### If you are using swift update AppDelegate.swift
 ```swift
 import UIKit
 
@@ -64,25 +64,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
-        
+
         showSplashScreen() // Call the method to display the splash screen
-        
+
         return true
     }
 
     //Add below method in AppDelegate.swift
 
     private func showSplashScreen() {
-        DispatchQueue.main.async {
             if let splashClass = NSClassFromString("SplashView") as? NSObject.Type,
                let splashInstance = splashClass.perform(NSSelectorFromString("sharedInstance"))?.takeUnretainedValue() as? NSObject {
                 splashInstance.perform(NSSelectorFromString("showSplash"))
             }
         }
-    }
 }
 ```
-### If you are using Obj C update AppDelegate.m or AppDelegate.mm 
+### If you are using Obj C update AppDelegate.m or AppDelegate.mm
 ```objc
 
 @implementation AppDelegate
@@ -93,13 +91,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   self.initialProps = @{};
 
   [self showSplashScreen]; // Call the method to display the splash screen
- 
+
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 
 // Add this method to AppDelegate.m
 - (void)showSplashScreen {
-    dispatch_async(dispatch_get_main_queue(), ^{
         Class splashClass = NSClassFromString(@"SplashView");
         if (splashClass) {
             id splashInstance = [splashClass performSelector:NSSelectorFromString(@"sharedInstance")];
@@ -107,15 +104,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 [splashInstance performSelector:NSSelectorFromString(@"showSplash")];
             }
         }
-    });
 }
 ```
 ---
 
-### **🤖 Android Setup**  
+### **🤖 Android Setup**
 
-#### **1️⃣ Create `launch_screen.xml` for Splash Screen**  
-Create the file **`android/app/src/main/res/layout/launch_screen.xml`** as per requirement:  
+#### **1️⃣ Create `launch_screen.xml` for Splash Screen**
+Create the file **`android/app/src/main/res/layout/launch_screen.xml`** as per requirement:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -133,8 +129,8 @@ Create the file **`android/app/src/main/res/layout/launch_screen.xml`** as per r
 </FrameLayout>
 ```
 
-#### **2️⃣ Optionally, Define a Custom Theme**  
-You can specify a theme in `android/app/src/main/res/values/styles.xml` and style name should be `SplashViewTheme`. 
+#### **2️⃣ Optionally, Define a Custom Theme**
+You can specify a theme in `android/app/src/main/res/values/styles.xml` and style name should be `SplashViewTheme`.
 
 ```xml
 <resources>
@@ -145,8 +141,8 @@ You can specify a theme in `android/app/src/main/res/values/styles.xml` and styl
 </resources>
 ```
 
-#### **3️⃣ Modify `MainActivity.kt` to Show the Splash Screen**  
-Update **`MainActivity.kt`** to display the splash screen on launch:  
+#### **3️⃣ Modify `MainActivity.kt` to Show the Splash Screen**
+Update **`MainActivity.kt`** to display the splash screen on launch:
 
 ```kotlin
 package com.example
@@ -166,9 +162,9 @@ class MainActivity : ReactActivity() {
 
 ---
 
-## **🚀 Usage**  
+## **🚀 Usage**
 
-### **Basic Example**  
+### **Basic Example**
 ```tsx
 import { hideSplash, showSplash } from 'react-native-splash-view';
 
@@ -184,7 +180,7 @@ useEffect(() => {
 
 ---
 
-## **⚙️ API**  
+## **⚙️ API**
 
 | Method          | Description                        |
 |----------------|----------------------------------|
@@ -193,17 +189,17 @@ useEffect(() => {
 
 ---
 
-## **🐞 Troubleshooting**  
+## **🐞 Troubleshooting**
 
-### **1️⃣ Cannot find `SplashView` in Pods folder (iOS)**  
+### **1️⃣ Cannot find `SplashView` in Pods folder (iOS)**
 
-Then run:  
+Then run:
 ```sh
 cd ios && pod install --repo-update && cd ..
 ```
 
-### **3️⃣ `SplashView` not found in `MainActivity.kt` (Android)**  
-Ensure your package is correctly linked. Run the following:  
+### **3️⃣ `SplashView` not found in `MainActivity.kt` (Android)**
+Ensure your package is correctly linked. Run the following:
 ```sh
 cd android && ./gradlew clean && cd ..
 npx react-native run-android
@@ -259,13 +255,13 @@ If you're using **React Native 0.75.x or below**, you may face issues with `Even
    This will apply the patch and fix issues related to **React Native 0.75.x and below**.
 
 ---
-## **💡 Contributing**  
-Feel free to open issues and pull requests! Contributions are welcome.  
+## **💡 Contributing**
+Feel free to open issues and pull requests! Contributions are welcome.
 
 ---
 
-## **📜 License**  
-This project is licensed under the **MIT License**.  
+## **📜 License**
+This project is licensed under the **MIT License**.
 
 ---
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1500,7 +1500,7 @@ PODS:
     - React-perflogger (= 0.77.1)
     - React-utils (= 0.77.1)
   - SocketRocket (0.7.1)
-  - SplashView (0.0.13):
+  - SplashView (0.0.17):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1743,7 +1743,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: ccc24d29d650ea725d582a9a53d57cd417fbdb53
-  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
+  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 664055db806cce35c3c1b43c84414dd66e117ae6
   RCTRequired: dc9a83fa1012054f94430d210337ca3a1afe6fc0
   RCTTypeSafety: 031cefa254a1df313a196f105b8fcffdab1c5ab6
@@ -1802,8 +1802,8 @@ SPEC CHECKSUMS:
   ReactCodegen: d9a09a7f7eee93f54d0b4135d5ca66b31b0c42a5
   ReactCommon: 08f4808f02ff115884e870e5cfea689703ff759a
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  SplashView: 86d79b6539cc36371834a07f8a8c7c6c3f40dd7a
-  Yoga: 2957d0e744897870b5a377f26522e3f08cadd7ac
+  SplashView: dc16ad6490524d105bd0e9927d43685586c62df1
+  Yoga: 1fd059161b449018342943b095a6d4e69bcaa719
 
 PODFILE CHECKSUM: a47ffb2ce1397ce664e7e96e986ed5d6caf658a1
 

--- a/example/ios/SplashViewExample/AppDelegate.swift
+++ b/example/ios/SplashViewExample/AppDelegate.swift
@@ -19,7 +19,6 @@ class AppDelegate: RCTAppDelegate {
   }
   
   private func showSplashScreen() {
-      DispatchQueue.main.async {
           if let splashClass = NSClassFromString("SplashView") as? NSObject.Type,
              let splashInstance = splashClass.perform(NSSelectorFromString("sharedInstance"))?.takeUnretainedValue() as? NSObject {
               splashInstance.perform(NSSelectorFromString("showSplash"))
@@ -27,7 +26,6 @@ class AppDelegate: RCTAppDelegate {
           } else {
               print("⚠️ SplashView module not found")
           }
-      }
   }
 
 


### PR DESCRIPTION
**The problem:**

White blinking was still there. That happened because showSplash() was executed in Main thread async queue, after RN instance was already initialized. That's why I've added a check, which will allow to execute showSplash() synchronously if we're already in main thread, and postpone an execution when we're not. For example - when we call showSplash() from JS side.

Also, the "FadeOut" effect was disappeared after last version urollout, so I've reverted animationDuration back to 0.3 second.

Please take a look, my dear friend!